### PR TITLE
update example test to use merchant

### DIFF
--- a/tests/e2e/specs/example.test.js
+++ b/tests/e2e/specs/example.test.js
@@ -6,12 +6,12 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { StoreOwnerFlow } from '@woocommerce/e2e-utils';
+import { merchant } from '@woocommerce/e2e-utils';
 
 const TIMEOUT = 20000;
 
 describe( 'Store Owner', () => {
 	it( 'Store owner can log in', async () => {
-		await StoreOwnerFlow.login();
+		await merchant.login();
 	}, TIMEOUT );
 } );


### PR DESCRIPTION
This PR updates the example test to use `merchant` instead of `StoreOwnerFlow`.

### Testing instructions

- Run E2E tests
- Should not get deprecated warning.

