### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This repo aims to provide a stripped down version of the default [WooCommerce E2
 ### Optional Node Packages
 
 * [**WooCommerce Core E2E Tests**](https://www.npmjs.com/package/@woocommerce/e2e-core-tests)
-* [**WordPress E2E Utils**](https://www.npmjs.com/package/@wordpress/e2e-test-utils) - All of this package is exported from `@woocommerce/e2e-utils`. However, you can install it directly if you choose.
 
 ---
 
@@ -71,7 +70,7 @@ npm i --save-dev @woocommerce/e2e-environment @woocommerce/e2e-utils @woocommerc
 * _Optional: Install the optional package listed below for the full WooCommerce e2e test suite_
 
 ```bash
-npm i --save-dev @woocommerce/e2e-core-tests @wordpress/e2e-test-utils
+npm i --save-dev @woocommerce/e2e-core-tests
 ```
 
 * Spin up Docker using **`npm run docker:up`**.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ This repo aims to provide a stripped down version of the default [WooCommerce E2
 
 ### Setup
 
-Note: the following assumes an existing WooCommerce extension with an existing `package.json`. 
+**Requirements**
+
+* Note that `npm@6` is required for setup
+* The following steps assumes there is an existing WooCommerce extension with an existing `package.json`. If your project does not contain a `package.json` file, create one using `npm init`. More information on this can be found [here](https://docs.npmjs.com/creating-a-package-json-file#creating-a-new-packagejson-file).
+
+**Steps**
 
 * Download the **[latest release](https://github.com/woocommerce/woocommerce-e2e-boilerplate/releases)** of this package to the root of your WooCommerce extension.
 * Modify **`tests/e2e/docker/initialize.sh`** as required.
@@ -50,13 +55,13 @@ Note: the following assumes an existing WooCommerce extension with an existing `
 * Install required packages as development dependencies.
 
 ```bash
-npm install --save-dev @woocommerce/e2e-environment @woocommerce/e2e-utils jest
+npm i --save-dev @woocommerce/e2e-environment @woocommerce/e2e-utils @woocommerce/api @wordpress/e2e-test-utils jest
 ```
 
-* _Optional: Install the optional packages listed above_
+* _Optional: Install the optional package listed below for the full WooCommerce e2e test suite_
 
 ```bash
-npm install --save-dev @woocommerce/e2e-core-tests @woocommerce/api @wordpress/e2e-test-utils
+npm i --save-dev @woocommerce/e2e-core-tests
 ```
 
 * Spin up Docker using **`npm run docker:up`**.

--- a/README.md
+++ b/README.md
@@ -18,22 +18,32 @@ This repo aims to provide a stripped down version of the default [WooCommerce E2
 
 * [**WooCommerce E2E Environment**](https://www.npmjs.com/package/@woocommerce/e2e-environment)
 * [**WooCommerce E2E Utils**](https://www.npmjs.com/package/@woocommerce/e2e-utils)
+* [**WooCommerce API**](https://www.npmjs.com/package/woocommerce-api)
 * [**Jest**](https://www.npmjs.com/package/jest)
 
 ### Optional Node Packages
 
 * [**WooCommerce Core E2E Tests**](https://www.npmjs.com/package/@woocommerce/e2e-core-tests)
-* [**WooCommerce API**](https://www.npmjs.com/package/woocommerce-api)
 * [**WordPress E2E Utils**](https://www.npmjs.com/package/@wordpress/e2e-test-utils) - All of this package is exported from `@woocommerce/e2e-utils`. However, you can install it directly if you choose.
 
 ---
 
-### Setup
+## Setup
 
 **Requirements**
 
-* Note that `npm@6` is required for setup
-* The following steps assumes there is an existing WooCommerce extension with an existing `package.json`. If your project does not contain a `package.json` file, create one using `npm init`. More information on this can be found [here](https://docs.npmjs.com/creating-a-package-json-file#creating-a-new-packagejson-file).
+* `npm@6` is required for setup. To install, run:
+```
+npm install -g npm@6
+```
+
+* The following steps are intended to be used with an existing WooCommerce extension that has a `package.json` file.
+  * If your project does not contain a `package.json` file, create one:
+
+```
+npm init
+```
+More information on creating a `package.json` file can be found [here](https://docs.npmjs.com/creating-a-package-json-file#creating-a-new-packagejson-file).
 
 **Steps**
 
@@ -55,13 +65,13 @@ This repo aims to provide a stripped down version of the default [WooCommerce E2
 * Install required packages as development dependencies.
 
 ```bash
-npm i --save-dev @woocommerce/e2e-environment @woocommerce/e2e-utils @woocommerce/api @wordpress/e2e-test-utils jest
+npm i --save-dev @woocommerce/e2e-environment @woocommerce/e2e-utils @woocommerce/api jest
 ```
 
 * _Optional: Install the optional package listed below for the full WooCommerce e2e test suite_
 
 ```bash
-npm i --save-dev @woocommerce/e2e-core-tests
+npm i --save-dev @woocommerce/e2e-core-tests @wordpress/e2e-test-utils
 ```
 
 * Spin up Docker using **`npm run docker:up`**.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To add new E2E tests, add new files to **`tests/e2e/specs/`**. **`tests/e2e/spec
 ### Relevant files
 
 * **Docker Initialization Script** - `tests/e2e/docker/initialize.sh`. This can be used to set up your testing environment such as installing additional plugins via WP-CLI / importing data / running additional scripts. Reference - https://github.com/woocommerce/woocommerce/blob/master/tests/e2e/docker/initialize.sh
-* **Jest Setup Script** - `tests/e2e/config/jest.setup.js`. Can be used to define custom scripts for Jest. You can also make use of the example script **`tests/e2e/config/jest.setup.example.js`** which requires **`@wordpress/e2e-test-utils`** package to be installed to run the defined functions. Please note that once the default template is enabled, all posts and products will be trashed, and local storage will be cleared between tests.
+* **Jest Setup Script** - `tests/e2e/config/jest.setup.js`. Can be used to define custom scripts for Jest. You can also make use of the example script **`tests/e2e/config/jest.setup.example.js`** which requires **`@woocommerce/e2e-utils`** package to be installed to run the defined functions. Please note that once the default template is enabled, all posts and products will be trashed, and local storage will be cleared between tests.
 * **Test Variables** - To override the default test variables, create a new JSON file at **`tests/e2e/config/default.json`**. Reference - https://github.com/woocommerce/woocommerce/blob/master/tests/e2e/env/config/default.json.
 
 ### Important References
@@ -103,7 +103,6 @@ To add new E2E tests, add new files to **`tests/e2e/specs/`**. **`tests/e2e/spec
 * **WooCommerce E2E Tests** - https://github.com/woocommerce/woocommerce/blob/master/tests/e2e/README.md
 * **WooCommerce E2E Environment** - https://www.npmjs.com/package/@woocommerce/e2e-environment
 * **WooCommerce E2E Core Tests** - https://www.npmjs.com/package/@woocommerce/e2e-core-tests
-* **WordPress E2E Test Utils** - https://www.npmjs.com/package/@wordpress/e2e-test-utils
 
 ### Changes made to the original WooCommerce E2E Test suite
 

--- a/tests/e2e/config/jest.setup.example.js
+++ b/tests/e2e/config/jest.setup.example.js
@@ -4,7 +4,7 @@ const {
 	switchUserToTest,
 	clearLocalStorage,
 	setBrowserViewport
-} = require( "@wordpress/e2e-test-utils" );
+} = require( "@woocommerce/e2e-utils" );
 
 /**
  * Navigates to the post listing screen and bulk-trashes any posts which exist.


### PR DESCRIPTION
This issue closes the following by updating the README:

* https://github.com/woocommerce/woocommerce-e2e-boilerplate/issues/8
* https://github.com/woocommerce/woocommerce-e2e-boilerplate/issues/7
* https://github.com/woocommerce/woocommerce-e2e-boilerplate/issues/6

Changes including noting the required NPM version, notes on adding a `package.json` if one doesn't exist, and reorganizing the required packages.