### PR TITLE
Added basic-auth plugin to initialize script

### DIFF
--- a/tests/e2e/docker/initialize.sh
+++ b/tests/e2e/docker/initialize.sh
@@ -26,6 +26,9 @@ wp plugin install wordpress-importer --activate
 echo "Importing WooCommerce sample products..."
 wp import wp-content/plugins/woocommerce/sample-data/sample_products.xml --authors=skip
 
+echo "Installing basic-auth to interact with the API..."
+wp plugin install https://github.com/WP-API/basic-auth/archive/master.zip --activate
+
 # echo "Activate <your-extension>"
 # wp plugin activate your-extension
 


### PR DESCRIPTION
This PR adds the basic-auth plugin to `tests/e2e/docker/initialize.sh` as it is required to interact with the API.

Closes https://github.com/woocommerce/woocommerce-e2e-boilerplate/issues/9