### PR TITLE
Add/core tests instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ const { runActivationTest } = require( '@woocommerce/e2e-core-tests' );
 runActivationTest();
 ```
 
+For more imformation about the core tests, including what tests are available, how to re-run tests, and general setup, please see the [WooCommerce Core End to End Test Suite README](https://github.com/woocommerce/woocommerce/blob/trunk/tests/e2e/core-tests/README.md).
+
 ### Relevant files
 
 * **Docker Initialization Script** - `tests/e2e/docker/initialize.sh`. This can be used to set up your testing environment such as installing additional plugins via WP-CLI / importing data / running additional scripts. Reference - https://github.com/woocommerce/woocommerce/blob/master/tests/e2e/docker/initialize.sh

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ To add new E2E tests, add new files to **`tests/e2e/specs/`**. **`tests/e2e/spec
 - Files with the extensions **`.test.js`** or **`.spec.js`** are run automatically by `npm run test:e2e`.
 - Adhoc tests can be created with the **`.js`** and executed with `npm run test:e2e tests/e2e/specs/test-example.js`.
 
+### Running core tests
+
+If you're installed the `@woocommerce/e2e-core-tests` and wish to run the tests within your project, note that all of the tests are wrapped in functions. In order to run the tests, create a local test spec and use the test function:
+
+```javascript
+const { runActivationTest } = require( '@woocommerce/e2e-core-tests' );
+
+runActivationTest();
+```
+
 ### Relevant files
 
 * **Docker Initialization Script** - `tests/e2e/docker/initialize.sh`. This can be used to set up your testing environment such as installing additional plugins via WP-CLI / importing data / running additional scripts. Reference - https://github.com/woocommerce/woocommerce/blob/master/tests/e2e/docker/initialize.sh

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To add new E2E tests, add new files to **`tests/e2e/specs/`**. **`tests/e2e/spec
 
 ### Running core tests
 
-If you're installed the `@woocommerce/e2e-core-tests` and wish to run the tests within your project, note that all of the tests are wrapped in functions. In order to run the tests, create a local test spec and use the test function:
+If you installed the optional `@woocommerce/e2e-core-tests` package and wish to run the tests within your project, note that all of the tests are wrapped in functions. In order to run the tests, create a local test spec and use the test function:
 
 ```javascript
 const { runActivationTest } = require( '@woocommerce/e2e-core-tests' );

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To add new E2E tests, add new files to **`tests/e2e/specs/`**. **`tests/e2e/spec
 
 ### Running core tests
 
-If you installed the optional `@woocommerce/e2e-core-tests` package and wish to run the tests within your project, note that all of the tests are wrapped in functions. In order to run the tests, create a local test spec and use the test function:
+If you installed the optional `@woocommerce/e2e-core-tests` package and wish to run the tests within your project, note that all of the tests are wrapped in functions. In order to run the tests, create a local test spec and use the test function. For example, to run the activation tests, you would need to do the following:
 
 ```javascript
 const { runActivationTest } = require( '@woocommerce/e2e-core-tests' );


### PR DESCRIPTION
This PR adds instructions on running the `@woocommerce/e2e-core-tests` to the README.

Closes https://github.com/woocommerce/woocommerce-e2e-boilerplate/issues/11