### PR TITLE
set permalinks, install mail logging in container initialzation

### DIFF
--- a/tests/e2e/docker/initialize.sh
+++ b/tests/e2e/docker/initialize.sh
@@ -5,7 +5,12 @@ wp plugin install woocommerce --activate
 wp theme install storefront --activate
 
 echo "Creating WooCommerce Customer Account"
-wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=password --role=customer --path=/var/www/html
+wp user create customer customer@woocommercecoree2etestsuite.com \
+	--user_pass=password \
+	--role=subscriber \
+	--first_name='Jane' \
+	--last_name='Smith' \
+	--path=/var/www/html
 
 echo "Adding basic WooCommerce settings..."
 wp option set woocommerce_store_address "Example Address Line 1"
@@ -16,6 +21,7 @@ wp option set woocommerce_store_postcode "94110"
 wp option set woocommerce_currency "USD"
 wp option set woocommerce_product_type "both"
 wp option set woocommerce_allow_tracking "no"
+wp rewrite structure /%postname%/
 
 echo "Importing WooCommerce shop pages..."
 wp wc --user=admin tool run install_pages
@@ -28,6 +34,9 @@ wp import wp-content/plugins/woocommerce/sample-data/sample_products.xml --autho
 
 echo "Installing basic-auth to interact with the API..."
 wp plugin install https://github.com/WP-API/basic-auth/archive/master.zip --activate
+
+# install the WP Mail Logging plugin to test emails
+wp plugin install wp-mail-logging --activate
 
 # echo "Activate <your-extension>"
 # wp plugin activate your-extension


### PR DESCRIPTION
Closes #10

Companion PR to https://github.com/woocommerce/woocommerce/pull/30741

This PP updates the container initialization to be more consistent with the core test container initialization

- Set the permalink structure to `/%postname%/`
- Install the mail logging plugin

### Testing

- Run `npx wc-e2e docker:up`
- Go to Settings -> Permalinks
- Verify the permalink structure is `/%postname%/`
- Go to Plugins
- Verify the mail logging plugin is installed and active