### PR TITLE
Update README with optional WC Admin package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repo aims to provide a stripped down version of the default [WooCommerce E2
 ### Optional Node Packages
 
 * [**WooCommerce Core E2E Tests**](https://www.npmjs.com/package/@woocommerce/e2e-core-tests)
+* [**WooCommerce Admin E2E Tests**](https://www.npmjs.com/package/@woocommerce/admin-e2e-tests)
 
 ---
 


### PR DESCRIPTION
This PR updates the README to include the [WooCommerce Admin e2e tests package](https://www.npmjs.com/package/@woocommerce/admin-e2e-tests) as an optional package.

Closes https://github.com/woocommerce/woocommerce-e2e-boilerplate/issues/25